### PR TITLE
New logic to skip service principal registration

### DIFF
--- a/AzureADApplicationRegistration/functions/Add-AzureADApp.ps1
+++ b/AzureADApplicationRegistration/functions/Add-AzureADApp.ps1
@@ -24,21 +24,27 @@ function Add-AzureADApp {
     ## Register Azure AD App
     # Check if the app already exists by comparing name and app ID URI stored in Azure Key vault.
     if ($AADAppName -eq (Get-AzureADApplication -SearchString $AADAppName).DisplayName `
-     -and (Get-AzureADApplication -SearchString $AADAppName).IdentifierUris `
-     -contains (Get-AzureKeyVaultSecret -VaultName $AzureKeyVaultName `
-     -Name ((Remove-EnvFromString -StringWithEnv $AADAppNameForId) + "IdentifierUris") -ErrorAction Stop).SecretValueText) {
+            -and (Get-AzureADApplication -SearchString $AADAppName).IdentifierUris `
+            -contains (Get-AzureKeyVaultSecret -VaultName $AzureKeyVaultName `
+                -Name ((Remove-EnvFromString -StringWithEnv $AADAppNameForId) + "IdentifierUris") -ErrorAction Stop).SecretValueText) {
         Write-Verbose "Application $AADAppName found"
         # Get App and App's SP
         $AADApp = Get-AzureADApplication -SearchString $AADAppName
-        $AADAppSP = Get-AzureADServicePrincipal -SearchString $AADAppName
+        
+        if (0 -eq $AzureTenantIdSecondary -and 0 -eq $AzureAdAppIdSecondary -and 0 -eq $AzureAdAppCertificateThumbprintSecondary) {
+            # Get service principal
+            $AADAppSP = Get-AzureADServicePrincipal -SearchString $AADAppName
+            # Add AD App's SP to hash table
+            $HashTable.Add("AppSPObjectID", $AADAppSP.ObjectId)
+        }
+        
         # Add details to hash table
         $HashTable.Add("AppName", $AADAppNameForId)
         # Add App's ID to hash table
         $HashTable.Add("AppID", $AADApp.AppId)
         # Add App's IdentifierUris to hash table
         $HashTable.Add("IdentifierUris", $AADApp.IdentifierUris[0])
-        # Add AD App's SP to hash table
-        $HashTable.Add("AppSPObjectID", $AADAppSP.ObjectId)
+
     }
     else {
         # Create AAD App
@@ -49,10 +55,15 @@ function Add-AzureADApp {
         $HashTable.Add("AppID", $AADApp.AppId)
         # Add App's IdentifierUris to hash table
         $HashTable.Add("IdentifierUris", $AADApp.IdentifierUris[0])
-        # Create SP for AAD App
-        $AADAppSP = New-AzureADServicePrincipal -AppId $AADApp.AppId
-        # Add AD App's SP to hash table
-        $HashTable.Add("AppSPObjectID", $AADAppSP.ObjectId)
+
+        if (0 -eq $AzureTenantIdSecondary -and 0 -eq $AzureAdAppIdSecondary -and 0 -eq $AzureAdAppCertificateThumbprintSecondary) {
+            # Create SP for AAD App
+            $AADAppSP = New-AzureADServicePrincipal -AppId $AADApp.AppId
+            # Add AD App's SP to hash table
+            $HashTable.Add("AppSPObjectID", $AADAppSP.ObjectId)
+
+        }
+
         # Create key for AAD App
         $AADAppKey = Add-AzureADAppKey -AADAppName $AADAppNameForId
         $HashTable.Add("Key", $AADAppKey)


### PR DESCRIPTION
New logic will skip Azure AD service principal registration if secondary (Hearings) teanant details are present. This change is backward compatible with the exiasting core-infra project.